### PR TITLE
Bugfix in person age calculation

### DIFF
--- a/src/js/eldp_generator.js
+++ b/src/js/eldp_generator.js
@@ -289,7 +289,7 @@ eldp_environment.eldp_generator = function(data){
 			//cheap and inaccurate way to calculate person's age, as wished by ELDP
 			if (bundle.bundle.date.year !== "" && bundle.bundle.date.year !== "YYYY"){
 				
-				var age = bundle.bundle.date.year - pers.birth_year;
+				var age = parseInt(bundle.bundle.date.year) - parseInt(pers.birth_year);
 				
 				if (typeof age == "number" && !(isNaN(age))){
 				


### PR DESCRIPTION
This fixes a bug that occurs when a person's birth year field is empty,
but a bundle date is given.
Since in JavaScript, 2016 - "" = 2016, you get very high and wrong
person's ages.
