### PR TITLE
update eldp_forms

### DIFF
--- a/src/js/eldp_forms.js
+++ b/src/js/eldp_forms.js
@@ -71,8 +71,8 @@ eldp_environment.bundle_form = {
 							name: "continent",
 							type: "select",
 							size: 1,
-							vocabulary: ["Unknown","Unspecified","Africa","Asia","Europe","Australia","Oceania","North-America","Middle-America","South-America"],
-							default_value: "Unspecified",
+							vocabulary: ["","Africa","Asia","Europe","Australia","Oceania","North-America","Middle-America","South-America"],
+							default_value: "",
 							comment: "The name of the continent where a recording was made or a photo was taken, for example Africa.",
 						},					
 						{


### PR DESCRIPTION
Values "Unkown" and "Unspecified" in "Continent" are not allowed and produce validation errors.
Solution: leave the field empty.
