### PR TITLE
replaces "lastModifiedDate" with "lastModified"

### DIFF
--- a/src/js/eldp_resources.js
+++ b/src/js/eldp_resources.js
@@ -430,7 +430,7 @@ eldp_environment.workflow[0] = (function(){
                 name: f.name,
                 mimeType: f.type || 'n/a',
                 size: strings.bytesToSize(f.size, 1),
-                lastModified: f.lastModifiedDate.toLocaleDateString(),
+                lastModified: f.lastModified
                 status: "stable"
             });
         }


### PR DESCRIPTION
"lastModifiedDate" is no longer supported by Firefox (see: https://developer.mozilla.org/en-US/docs/Web/API/File/lastModifiedDate#Specifications) and caused a bug preventing users from importing resources. Replacing it with simply "lastModified" fixes this.